### PR TITLE
乱数をcrypto.randomBytes()関数に変更

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -91,7 +91,7 @@ function addTrackingCookie(cookies, userName) {
   if (isValidTrackingId(requestedTrackingId, userName)) {
     return requestedTrackingId;
   } else {
-    const originalId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+    const originalId = parseInt(crypto.randomBytes(8).toString('hex'), 16);
     const tomorrow = new Date(new Date().getTime() + (1000 * 60 * 60 * 24));
     const trackingId = originalId + '_' + createValidHash(originalId, userName);
     cookies.set(trackingIdKey, trackingId, { expires: tomorrow });


### PR DESCRIPTION
練習用なのでマージ不要です。